### PR TITLE
Add endpoints found in Discord Webpack API output

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -158,6 +158,8 @@ Base-URL: https://canary.discord.com/api/v9
 ### /users/@me/guilds/premium/subscription-slots
 ### /users/@me/guilds/premium/subscriptions/cooldown
 ### /users/@me/harvest
+<!-- Found in Discord Webpack API output (x.ANM) -->
+### /users/@me/invites
 ### /users/@me/library
 ### /users/@me/mentions
 ### /users/@me/notes
@@ -186,3 +188,11 @@ Base-URL: https://canary.discord.com/api/v9
 ### /guilds/:guild-id/prune
 ### /guilds/:guild-id/integrations
 ### /guilds/:guild-id/integrations/:integration-id/sync
+&nbsp;
+<!-- Found in Discord Webpack API output (x.ANM) -->
+### /users/@me/invites
+
+# DELETE (Not finished)
+
+<!-- Found in Discord Webpack API output (x.ANM) -->
+### /users/@me/invites


### PR DESCRIPTION
Yes, it's real. If you un-minify https://discord.com/assets/91d56d9b791b3d7a4409.js , and then go to line ~102315, you will find endpoints for something called Friend Invites.

This is a secret Discord feature that allows you to create invites that automatically add the user as a friend as if the user was a channel or guild.

~~Currently, it seems valid creation is only available on the Discord client using some code in the client application's console like [this gist](https://gist.github.com/oSumAtrIX/8c0540c80ca2b91efa18d137e239570f).~~

Valid creation is available, you just need a token from a user account. This is considered selfbotting, however.